### PR TITLE
Fix compilation errors in project

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/App.kt
+++ b/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/App.kt
@@ -1,6 +1,5 @@
 package com.guyghost.wakeve
 
-import SyncStatusIndicator
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -59,7 +58,11 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
     }
 
     override suspend fun updateEvent(event: Event): Result<Event> {
-        TODO("Not yet implemented")
+        return eventRepository.updateEvent(event).also { result ->
+            if (result.isSuccess) {
+                syncManager.triggerSync()
+            }
+        }
     }
 
     override suspend fun updateEventStatus(id: String, status: EventStatus, finalDate: String?): Result<Boolean> {

--- a/composeApp/src/jvmMain/kotlin/com/guyghost/wakeve/App.kt
+++ b/composeApp/src/jvmMain/kotlin/com/guyghost/wakeve/App.kt
@@ -11,6 +11,8 @@ import com.guyghost.wakeve.models.Event
 import com.guyghost.wakeve.models.EventStatus
 import com.guyghost.wakeve.models.Vote
 import com.guyghost.wakeve.sync.SyncManager
+import com.guyghost.wakeve.sync.KtorSyncHttpClient
+import com.guyghost.wakeve.sync.JvmNetworkStatusDetector
 import kotlinx.coroutines.launch
 
 /**
@@ -47,6 +49,14 @@ class SyncedEventRepository(
 
     override suspend fun addVote(eventId: String, participantId: String, slotId: String, vote: Vote): Result<Boolean> {
         return eventRepository.addVote(eventId, participantId, slotId, vote).also { result ->
+            if (result.isSuccess) {
+                syncManager.triggerSync()
+            }
+        }
+    }
+
+    override suspend fun updateEvent(event: Event): Result<Event> {
+        return eventRepository.updateEvent(event).also { result ->
             if (result.isSuccess) {
                 syncManager.triggerSync()
             }


### PR DESCRIPTION
- Remove incorrect import 'SyncStatusIndicator' in Android App.kt
- Add missing imports for KtorSyncHttpClient and JvmNetworkStatusDetector in JVM App.kt
- Implement missing updateEvent method in Android SyncedEventRepository
- Implement missing updateEvent method in JVM SyncedEventRepository

These changes ensure EventRepositoryInterface is fully implemented on all platforms and resolve import errors that would prevent compilation.

## Change ID
`<verb-led-id>`

## Related Issue
Relates to #<issue-number>

## Proposal Summary
<!-- Brief overview of the change and its rationale -->

### Problem Statement
<!-- What problem does this change solve? -->

### Proposed Solution
<!-- High-level approach to solving the problem -->

### Benefits
<!-- What value does this change provide? -->

### Trade-offs
<!-- What are the drawbacks or limitations? -->

## Documentation
- **Design Details**: [Wiki - Design](https://github.com/<org>/<repo>/wiki/changes/<id>/design)
- **Spec Deltas**: [Wiki - Specs](https://github.com/<org>/<repo>/wiki/changes/<id>/specs)
- **Task Tracking**: #<issue-number>

## Affected Specifications
<!-- List the specifications that will be modified -->
- `openspec/specs/<spec-name>.md` - Brief description of changes

## Validation
```bash
# Validation results
openspec validate <id> --strict
```

- [ ] All validations pass
- [ ] Scenarios included for each requirement
- [ ] Design documented in wiki
- [ ] Specs documented in wiki
- [ ] No breaking changes (or documented if unavoidable)

## Review Checklist
- [ ] Proposal is clear and well-motivated
- [ ] Design is technically sound
- [ ] Spec deltas follow required format
- [ ] Scenarios adequately cover requirements
- [ ] Documentation is complete

## Next Steps
<!-- What happens after this proposal is approved? -->
1. Implement changes based on approved design
2. Update task checklist in issue #<issue-number>
3. Create follow-up PRs for actual implementation
