### PR TITLE
feat(android): add optional release signing configuration

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -98,6 +98,17 @@ Backend target:
 - For emulator-local backend development, add `server.url=http://10.0.2.2:8080` to `local.properties`.
 - For command-line overrides, pass `-Pwakeve.serverUrl=http://10.0.2.2:8080`.
 
+Release signing (do not commit keystore files or passwords):
+
+```properties
+RELEASE_STORE_FILE=path/to/upload-keystore.jks
+RELEASE_STORE_PASSWORD=your-store-password
+RELEASE_KEY_ALIAS=your-key-alias
+RELEASE_KEY_PASSWORD=your-key-password
+```
+
+Add these to `local.properties` for local release builds, or export the same names as environment variables in CI. Release builds are signed only when all four values are present.
+
 Build:
 
 ```bash

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -30,6 +30,26 @@ val serverUrl = (localProperties["server.url"] as? String)
     ?: "https://api.wakeve.app"
 val escapedServerUrl = serverUrl.replace("\\", "\\\\").replace("\"", "\\\"")
 
+// Release signing: set in local.properties (gitignored) or CI environment variables.
+// RELEASE_STORE_FILE=path/to/upload-keystore.jks
+// RELEASE_STORE_PASSWORD=...
+// RELEASE_KEY_ALIAS=...
+// RELEASE_KEY_PASSWORD=...
+fun readReleaseSigningProperty(name: String): String? =
+    (localProperties[name] as? String)?.trim()?.takeIf { it.isNotEmpty() }
+        ?: System.getenv(name)?.trim()?.takeIf { it.isNotEmpty() }
+
+val releaseStoreFile = readReleaseSigningProperty("RELEASE_STORE_FILE")
+val releaseStorePassword = readReleaseSigningProperty("RELEASE_STORE_PASSWORD")
+val releaseKeyAlias = readReleaseSigningProperty("RELEASE_KEY_ALIAS")
+val releaseKeyPassword = readReleaseSigningProperty("RELEASE_KEY_PASSWORD")
+val hasReleaseSigningConfig = listOf(
+    releaseStoreFile,
+    releaseStorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword
+).all { !it.isNullOrBlank() }
+
 kotlin {
     // Android target
     androidTarget {
@@ -202,9 +222,23 @@ android {
         }
     }
     
+    signingConfigs {
+        if (hasReleaseSigningConfig) {
+            create("release") {
+                storeFile = rootProject.file(releaseStoreFile!!)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
+            if (hasReleaseSigningConfig) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- Add optional `signingConfigs.release` driven by `RELEASE_*` properties/env vars
- Apply release signing only when all four values are present
- Document local and CI setup in `QUICK_START.md`

## Test plan
- [ ] `./gradlew :composeApp:bundleRelease` without signing props (unsigned release build)
- [ ] `./gradlew :composeApp:bundleRelease` with all `RELEASE_*` values set (signed AAB)

Made with [Cursor](https://cursor.com)