### PR TITLE
feat(auth): add account deletion gateway and state machine

### DIFF
--- a/shared/src/commonMain/kotlin/com/guyghost/wakeve/auth/shell/services/AccountDeletionGateway.kt
+++ b/shared/src/commonMain/kotlin/com/guyghost/wakeve/auth/shell/services/AccountDeletionGateway.kt
@@ -1,0 +1,21 @@
+package com.guyghost.wakeve.auth.shell.services
+
+import com.guyghost.wakeve.models.AccountDeletionResponse
+
+/**
+ * Deletes the authenticated Wakeve account on the backend.
+ *
+ * Local credentials must only be cleared after this call succeeds so offline
+ * failures remain retryable and do not falsely imply backend erasure.
+ */
+interface AccountDeletionGateway {
+    suspend fun deleteAccount(accessToken: String): Result<AccountDeletionResponse>
+}
+
+/**
+ * Default gateway used when no platform implementation is configured.
+ */
+class UnconfiguredAccountDeletionGateway : AccountDeletionGateway {
+    override suspend fun deleteAccount(accessToken: String): Result<AccountDeletionResponse> =
+        Result.failure(IllegalStateException("Account deletion is not configured"))
+}

--- a/shared/src/commonMain/kotlin/com/guyghost/wakeve/auth/shell/statemachine/AuthContract.kt
+++ b/shared/src/commonMain/kotlin/com/guyghost/wakeve/auth/shell/statemachine/AuthContract.kt
@@ -115,6 +115,16 @@ object AuthContract {
          * Sign out the current user.
          */
         data object SignOut : Intent
+
+        /**
+         * Delete the authenticated account after server-confirmed erasure.
+         */
+        data object DeleteAccount : Intent
+
+        /**
+         * Delete local-only guest data without contacting the backend.
+         */
+        data object DeleteGuestData : Intent
     }
 
     /**
@@ -165,5 +175,10 @@ object AuthContract {
          * Animate the success state.
          */
         data object AnimateSuccess : SideEffect
+
+        /**
+         * Navigate to the auth screen after account or guest data deletion.
+         */
+        data object NavigateToAuthAfterDeletion : SideEffect
     }
 }

--- a/shared/src/commonMain/kotlin/com/guyghost/wakeve/auth/shell/statemachine/AuthStateMachine.kt
+++ b/shared/src/commonMain/kotlin/com/guyghost/wakeve/auth/shell/statemachine/AuthStateMachine.kt
@@ -8,6 +8,8 @@ import com.guyghost.wakeve.auth.core.models.AuthMethod
 import com.guyghost.wakeve.auth.shell.services.AuthService
 import com.guyghost.wakeve.auth.shell.services.EmailAuthService
 import com.guyghost.wakeve.auth.shell.services.GuestModeService
+import com.guyghost.wakeve.auth.shell.services.AccountDeletionGateway
+import com.guyghost.wakeve.auth.shell.services.UnconfiguredAccountDeletionGateway
 import com.guyghost.wakeve.auth.shell.services.TokenStorage
 import com.guyghost.wakeve.auth.shell.services.TokenKeys
 import com.guyghost.wakeve.auth.shell.statemachine.AuthContract.Intent
@@ -49,6 +51,7 @@ class AuthStateMachine(
     private val emailAuthService: EmailAuthService,
     private val guestModeService: GuestModeService,
     private val tokenStorage: TokenStorage,
+    private val accountDeletionGateway: AccountDeletionGateway = UnconfiguredAccountDeletionGateway(),
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 ) {
     private val _state = MutableStateFlow(State.initial())
@@ -82,6 +85,8 @@ class AuthStateMachine(
             is Intent.CheckExistingSession -> handleCheckSession()
             is Intent.ClearError -> handleClearError()
             is Intent.SignOut -> handleSignOut()
+            is Intent.DeleteAccount -> handleDeleteAccount()
+            is Intent.DeleteGuestData -> handleDeleteGuestData()
         }
     }
 
@@ -351,6 +356,58 @@ class AuthStateMachine(
             }
 
             emitSideEffect(SideEffect.NavigateBack)
+        }
+    }
+
+    private fun handleDeleteAccount() {
+        if (_state.value.isGuest) {
+            handleDeleteGuestData()
+            return
+        }
+
+        updateState { copy(isLoading = true, lastError = null) }
+
+        scope.launch {
+            val accessToken = tokenStorage.getString(TokenKeys.ACCESS_TOKEN)
+            if (accessToken.isNullOrBlank()) {
+                updateState { copy(isLoading = false) }
+                emitSideEffect(SideEffect.ShowError("Authentification requise"))
+                return@launch
+            }
+
+            accountDeletionGateway.deleteAccount(accessToken).fold(
+                onSuccess = {
+                    completeLocalAccountDeletion()
+                    emitSideEffect(SideEffect.ShowSuccess("Compte supprimé"))
+                    emitSideEffect(SideEffect.NavigateToAuthAfterDeletion)
+                },
+                onFailure = {
+                    updateState { copy(isLoading = false) }
+                    emitSideEffect(SideEffect.ShowError("Impossible de supprimer le compte. Réessayez."))
+                }
+            )
+        }
+    }
+
+    private fun handleDeleteGuestData() {
+        updateState { copy(isLoading = true, lastError = null) }
+
+        scope.launch {
+            completeLocalAccountDeletion()
+            emitSideEffect(SideEffect.ShowSuccess("Données invité supprimées"))
+            emitSideEffect(SideEffect.NavigateToAuthAfterDeletion)
+        }
+    }
+
+    private suspend fun completeLocalAccountDeletion() {
+        tokenStorage.clearAll()
+        guestModeService.endGuestSession()
+        authService.signOut()
+
+        updateState {
+            State.initial().copy(
+                isProviderAvailable = isProviderAvailable
+            )
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/guyghost/wakeve/models/UserModels.kt
+++ b/shared/src/commonMain/kotlin/com/guyghost/wakeve/models/UserModels.kt
@@ -110,6 +110,18 @@ data class TokenRefreshResponse(
 )
 
 /**
+ * Response returned after an authenticated account deletion request.
+ */
+@Serializable
+data class AccountDeletionResponse(
+    val success: Boolean,
+    val deleted: Boolean,
+    val message: String,
+    val localCleanupRequired: Boolean,
+    val providerRevocationStatus: String
+)
+
+/**
  * Authentication middleware context
  */
 data class AuthContext(

--- a/shared/src/jvmTest/kotlin/com/guyghost/wakeve/auth/shell/statemachine/AuthStateMachineAccountDeletionTest.kt
+++ b/shared/src/jvmTest/kotlin/com/guyghost/wakeve/auth/shell/statemachine/AuthStateMachineAccountDeletionTest.kt
@@ -1,0 +1,147 @@
+package com.guyghost.wakeve.auth.shell.statemachine
+
+import com.guyghost.wakeve.auth.shell.services.AccountDeletionGateway
+import com.guyghost.wakeve.auth.shell.services.AuthService
+import com.guyghost.wakeve.auth.shell.services.EmailAuthService
+import com.guyghost.wakeve.auth.shell.services.GuestModeService
+import com.guyghost.wakeve.auth.shell.services.TokenKeys
+import com.guyghost.wakeve.auth.shell.services.TokenStorage
+import com.guyghost.wakeve.models.AccountDeletionResponse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthStateMachineAccountDeletionTest {
+
+    @Test
+    fun deleteAccount_clearsLocalStateAfterBackendSuccess() = runTest {
+        val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        val tokenStorage = RecordingTokenStorage()
+        tokenStorage.storeString(TokenKeys.ACCESS_TOKEN, "access-token")
+        val gateway = FakeAccountDeletionGateway(
+            Result.success(
+                AccountDeletionResponse(
+                    success = true,
+                    deleted = true,
+                    message = "Account deleted successfully",
+                    localCleanupRequired = true,
+                    providerRevocationStatus = "NOT_APPLICABLE"
+                )
+            )
+        )
+        val stateMachine = AuthStateMachine(
+            authService = AuthService(tokenStorage = tokenStorage),
+            emailAuthService = EmailAuthService(),
+            guestModeService = GuestModeService(tokenStorage),
+            tokenStorage = tokenStorage,
+            accountDeletionGateway = gateway,
+            scope = scope
+        )
+
+        stateMachine.handleIntent(AuthContract.Intent.DeleteAccount)
+
+        assertTrue(gateway.deleteCalled)
+        assertFalse(tokenStorage.hasAccessToken)
+        assertFalse(stateMachine.state.value.isAuthenticated)
+        assertFalse(stateMachine.state.value.isGuest)
+    }
+
+    @Test
+    fun deleteAccount_keepsCredentialsWhenBackendFails() = runTest {
+        val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        val tokenStorage = RecordingTokenStorage()
+        tokenStorage.storeString(TokenKeys.ACCESS_TOKEN, "access-token")
+        val gateway = FakeAccountDeletionGateway(Result.failure(Exception("network")))
+        val stateMachine = AuthStateMachine(
+            authService = AuthService(tokenStorage = tokenStorage),
+            emailAuthService = EmailAuthService(),
+            guestModeService = GuestModeService(tokenStorage),
+            tokenStorage = tokenStorage,
+            accountDeletionGateway = gateway,
+            scope = scope
+        )
+
+        stateMachine.handleIntent(AuthContract.Intent.DeleteAccount)
+
+        assertTrue(gateway.deleteCalled)
+        assertTrue(tokenStorage.hasAccessToken)
+    }
+
+    @Test
+    fun deleteGuestData_clearsLocalGuestSessionWithoutBackendCall() = runTest {
+        val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+        val tokenStorage = RecordingTokenStorage()
+        tokenStorage.storeString("guest_user_id", "guest-123")
+        val gateway = FakeAccountDeletionGateway(
+            Result.success(
+                AccountDeletionResponse(
+                    success = true,
+                    deleted = true,
+                    message = "unused",
+                    localCleanupRequired = true,
+                    providerRevocationStatus = "NOT_APPLICABLE"
+                )
+            )
+        )
+        val stateMachine = AuthStateMachine(
+            authService = AuthService(tokenStorage = tokenStorage),
+            emailAuthService = EmailAuthService(),
+            guestModeService = GuestModeService(tokenStorage),
+            tokenStorage = tokenStorage,
+            accountDeletionGateway = gateway,
+            scope = scope
+        )
+
+        stateMachine.handleIntent(AuthContract.Intent.DeleteGuestData)
+
+        assertFalse(gateway.deleteCalled)
+        assertFalse(tokenStorage.contains("guest_user_id"))
+    }
+
+    private class FakeAccountDeletionGateway(
+        private val result: Result<AccountDeletionResponse>
+    ) : AccountDeletionGateway {
+        var deleteCalled = false
+
+        override suspend fun deleteAccount(accessToken: String): Result<AccountDeletionResponse> {
+            deleteCalled = true
+            assertEquals("access-token", accessToken)
+            return result
+        }
+    }
+
+    private class RecordingTokenStorage : TokenStorage {
+        private val storage = mutableMapOf<String, String>()
+        var hasAccessToken = false
+
+        override suspend fun storeString(key: String, value: String) {
+            storage[key] = value
+            if (key == TokenKeys.ACCESS_TOKEN) {
+                hasAccessToken = true
+            }
+        }
+
+        override suspend fun getString(key: String): String? = storage[key]
+
+        override suspend fun remove(key: String) {
+            storage.remove(key)
+            if (key == TokenKeys.ACCESS_TOKEN) {
+                hasAccessToken = false
+            }
+        }
+
+        override suspend fun contains(key: String): Boolean = storage.containsKey(key)
+
+        override suspend fun clearAll() {
+            storage.clear()
+            hasAccessToken = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AccountDeletionGateway` interface and `AccountDeletionResponse` model
- Extend auth contract/state machine with account and guest data deletion intents
- Clear credentials only after successful backend deletion; add JVM unit tests

## Test plan
- [ ] `./gradlew shared:jvmTest --tests "*AuthStateMachineAccountDeletionTest*"`

Made with [Cursor](https://cursor.com)