### PR TITLE
feat(android): add in-app account deletion UI

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/auth/AndroidAccountDeletionGateway.kt
+++ b/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/auth/AndroidAccountDeletionGateway.kt
@@ -1,0 +1,43 @@
+package com.guyghost.wakeve.auth
+
+import com.guyghost.wakeve.BuildConfig
+import com.guyghost.wakeve.auth.shell.services.AccountDeletionGateway
+import com.guyghost.wakeve.models.AccountDeletionResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Android implementation of authenticated account deletion against the Wakeve API.
+ */
+class AndroidAccountDeletionGateway(
+    serverBaseUrl: String = resolveAndroidAuthServerBaseUrl(BuildConfig.SERVER_URL),
+    private val httpClient: HttpClient = HttpClient {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+    }
+) : AccountDeletionGateway {
+
+    private val apiBaseUrl = serverBaseUrl
+
+    override suspend fun deleteAccount(accessToken: String): Result<AccountDeletionResponse> = runCatching {
+        val response = httpClient.delete("$apiBaseUrl/api/user/delete") {
+            header("Authorization", "Bearer $accessToken")
+            header("Accept", "application/json")
+        }
+
+        when (response.status) {
+            HttpStatusCode.OK -> response.body<AccountDeletionResponse>()
+            HttpStatusCode.Unauthorized -> throw AccountDeletionException("Authentication required")
+            else -> throw AccountDeletionException("Account deletion failed")
+        }
+    }
+}
+
+internal class AccountDeletionException(message: String) : Exception(message)

--- a/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/di/PlatformModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/di/PlatformModule.android.kt
@@ -22,6 +22,7 @@ import com.guyghost.wakeve.auth.shell.services.AndroidTokenStorage
 import com.guyghost.wakeve.auth.shell.services.AuthService
 import com.guyghost.wakeve.auth.shell.services.EmailAuthService
 import com.guyghost.wakeve.auth.shell.services.GuestModeService
+import com.guyghost.wakeve.auth.shell.services.AccountDeletionGateway
 import com.guyghost.wakeve.auth.shell.services.TokenStorage
 import com.guyghost.wakeve.auth.shell.statemachine.AuthStateMachine
 import com.guyghost.wakeve.auth.SessionRepository
@@ -33,6 +34,7 @@ import com.guyghost.wakeve.notification.NotificationPreferencesRepositoryInterfa
 import com.guyghost.wakeve.notification.NotificationService
 import com.guyghost.wakeve.repository.ScenarioRepository
 import com.guyghost.wakeve.ui.auth.AuthViewModel
+import com.guyghost.wakeve.auth.AndroidAccountDeletionGateway
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -167,6 +169,10 @@ fun platformModule(): Module = module {
     single {
         GuestModeService(tokenStorage = get())
     }
+
+    single<AccountDeletionGateway> {
+        AndroidAccountDeletionGateway()
+    }
     
     /**
      * Provide AuthStateMachine singleton.
@@ -182,6 +188,7 @@ fun platformModule(): Module = module {
             emailAuthService = get(),
             guestModeService = get(),
             tokenStorage = get(),
+            accountDeletionGateway = get(),
             scope = scope
         )
     }

--- a/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/navigation/Screen.kt
+++ b/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/navigation/Screen.kt
@@ -141,6 +141,7 @@ sealed class Screen(val route: String) {
 
     // Settings
     data object Settings : Screen("settings")
+    data object DataManagement : Screen("settings/data_management")
 
     // Notifications
     data object Notifications : Screen("notifications?$NOTIFICATIONS_FILTER_ARG={$NOTIFICATIONS_FILTER_ARG}") {

--- a/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/navigation/WakeveNavHost.kt
+++ b/composeApp/src/androidMain/kotlin/com/guyghost/wakeve/navigation/WakeveNavHost.kt
@@ -36,6 +36,7 @@ import com.guyghost.wakeve.InboxScreen
 import com.guyghost.wakeve.OnboardingScreen
 import com.guyghost.wakeve.ProfileTabScreen
 import com.guyghost.wakeve.SettingsScreen
+import com.guyghost.wakeve.DataManagementScreen
 import com.guyghost.wakeve.SplashScreen
 import com.guyghost.wakeve.deeplink.AndroidInvitationShareService
 import com.guyghost.wakeve.deeplink.AndroidNavigationDeepLinkHandler
@@ -291,8 +292,11 @@ fun WakeveNavHost(
                         }
                         is AuthSideEffect.ShowOTPInput,
                         is AuthSideEffect.HapticFeedback,
-                        is AuthSideEffect.AnimateSuccess -> {
-                            // Handled by EmailAuthScreen or ignored
+                        is AuthSideEffect.AnimateSuccess,
+                        is AuthSideEffect.NavigateToAuth -> {
+                            navController.navigate(Screen.Auth.route) {
+                                popUpTo(0) { inclusive = true }
+                            }
                         }
                     }
                 }
@@ -1207,9 +1211,62 @@ fun WakeveNavHost(
                 onCreateAccount = {
                     navController.navigate(Screen.Auth.route)
                 },
+                onOpenDataManagement = {
+                    navController.navigate(Screen.DataManagement.route)
+                },
                 onBack = {
                     navController.navigateUp()
                 }
+            )
+        }
+
+        composable(Screen.DataManagement.route) {
+            val authViewModel: AuthViewModel = koinInject()
+            val authState by authViewModel.uiState.collectAsState()
+            val context = LocalContext.current
+            var deletionError by remember { mutableStateOf<String?>(null) }
+            var deletionSuccess by remember { mutableStateOf<String?>(null) }
+
+            LaunchedEffect(Unit) {
+                authViewModel.sideEffects.collect { effect ->
+                    when (effect) {
+                        is AuthSideEffect.ShowError -> {
+                            deletionError = effect.message
+                            deletionSuccess = null
+                            Toast.makeText(context, effect.message, Toast.LENGTH_LONG).show()
+                        }
+                        is AuthSideEffect.ShowSuccess -> {
+                            deletionSuccess = effect.message
+                            deletionError = null
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                        }
+                        is AuthSideEffect.NavigateToAuth -> {
+                            navController.navigate(Screen.Auth.route) {
+                                popUpTo(0) { inclusive = true }
+                            }
+                        }
+                        else -> Unit
+                    }
+                }
+            }
+
+            DataManagementScreen(
+                isGuest = authState.isGuest,
+                isDeleting = authState.isLoading,
+                errorMessage = deletionError,
+                successMessage = deletionSuccess,
+                onConfirmDeletion = {
+                    deletionError = null
+                    deletionSuccess = null
+                    if (authState.isGuest) {
+                        authViewModel.deleteGuestData()
+                    } else {
+                        authViewModel.deleteCurrentAccount()
+                    }
+                },
+                onDismissError = { deletionError = null },
+                onDismissSuccess = { deletionSuccess = null },
+                onBack = { navController.navigateUp() }
             )
         }
         

--- a/composeApp/src/androidUnitTest/kotlin/com/guyghost/wakeve/DataManagementScreenContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/guyghost/wakeve/DataManagementScreenContractTest.kt
@@ -1,0 +1,21 @@
+package com.guyghost.wakeve
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DataManagementScreenContractTest {
+    @Test
+    fun dataManagementMessagesUseStableSafeCopy() {
+        val messages = listOf(
+            accountDeletionFailureMessage(),
+            guestDataDeletionSuccessMessage(),
+            accountDeletionSuccessMessage()
+        )
+
+        assertEquals(messages.size, messages.distinct().size)
+        messages.forEach { message ->
+            assertFalse(message.isBlank())
+        }
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/guyghost/wakeve/auth/AndroidAccountDeletionGatewayContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/guyghost/wakeve/auth/AndroidAccountDeletionGatewayContractTest.kt
@@ -1,0 +1,24 @@
+package com.guyghost.wakeve.auth
+
+import org.junit.Test
+import kotlin.test.assertContains
+import java.io.File
+
+class AndroidAccountDeletionGatewayContractTest {
+    @Test
+    fun androidAccountDeletionGatewayCallsStableDeleteRoute() {
+        val source = projectFile(
+            "composeApp/src/androidMain/kotlin/com/guyghost/wakeve/auth/AndroidAccountDeletionGateway.kt"
+        ).readText()
+
+        assertContains(source, "/api/user/delete")
+        assertContains(source, "Bearer")
+        assertContains(source, "AccountDeletionResponse")
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val root = generateSequence(File(System.getProperty("user.dir")).absoluteFile) { it.parentFile }
+            .first { File(it, relativePath).exists() }
+        return File(root, relativePath)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/guyghost/wakeve/DataManagementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/guyghost/wakeve/DataManagementScreen.kt
@@ -1,0 +1,221 @@
+package com.guyghost.wakeve
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material.icons.filled.PersonOff
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Data management screen for account and guest data deletion.
+ *
+ * Mirrors iOS DataManagementView with Material You styling.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DataManagementScreen(
+    isGuest: Boolean,
+    isDeleting: Boolean,
+    errorMessage: String?,
+    successMessage: String?,
+    onConfirmDeletion: () -> Unit,
+    onDismissError: () -> Unit,
+    onDismissSuccess: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var showDeletionConfirmation by remember { mutableStateOf(false) }
+    val destructiveTitle = if (isGuest) "Supprimer les données invité" else "Supprimer le compte"
+    val scopeDescription = if (isGuest) {
+        "Cette action supprime uniquement les données locales de cet appareil en mode invité."
+    } else {
+        "Cette action supprime votre compte Wakeve, vos données personnelles et révoque votre session sur cet appareil."
+    }
+    val confirmationMessage = if (isGuest) {
+        "Les données locales de cet appareil seront effacées. Cette action est irréversible."
+    } else {
+        "Votre compte et vos données personnelles seront supprimés. Cette action est irréversible."
+    }
+
+    if (showDeletionConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showDeletionConfirmation = false },
+            title = { Text(destructiveTitle) },
+            text = { Text(confirmationMessage) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeletionConfirmation = false
+                        onConfirmDeletion()
+                    }
+                ) {
+                    Text(destructiveTitle, color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeletionConfirmation = false }) {
+                    Text("Annuler")
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Gestion des données") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Contrôlez la suppression de vos données Wakeve sur cet appareil.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Shield,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = "Portée de la suppression",
+                        style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold)
+                    )
+                    Text(
+                        text = scopeDescription,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            errorMessage?.let { error ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        TextButton(onClick = onDismissError) {
+                            Text("Fermer")
+                        }
+                    }
+                }
+            }
+
+            successMessage?.let { success ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                    )
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = success,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onTertiaryContainer
+                        )
+                        TextButton(onClick = onDismissSuccess) {
+                            Text("Fermer")
+                        }
+                    }
+                }
+            }
+
+            if (isDeleting) {
+                CircularProgressIndicator(modifier = Modifier.padding(top = 8.dp))
+            } else {
+                Button(
+                    onClick = { showDeletionConfirmation = true },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Icon(
+                        imageVector = if (isGuest) Icons.Default.DeleteForever else Icons.Default.PersonOff,
+                        contentDescription = null
+                    )
+                    Text(
+                        text = destructiveTitle,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+internal fun accountDeletionFailureMessage(): String =
+    "Impossible de supprimer le compte. Réessayez."
+
+internal fun guestDataDeletionSuccessMessage(): String =
+    "Données invité supprimées"
+
+internal fun accountDeletionSuccessMessage(): String =
+    "Compte supprimé"

--- a/composeApp/src/commonMain/kotlin/com/guyghost/wakeve/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/guyghost/wakeve/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -85,6 +86,7 @@ data class SessionDisplayData(
  * @param userName The user's display name (if authenticated)
  * @param onLogout Callback when user taps logout
  * @param onCreateAccount Callback when guest taps "Create Account"
+ * @param onOpenDataManagement Callback when user opens data management
  * @param onBack Callback when user taps back
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -99,6 +101,7 @@ fun SettingsScreen(
     sessionRepository: SessionRepository? = null,
     onLogout: () -> Unit,
     onCreateAccount: () -> Unit = {},
+    onOpenDataManagement: () -> Unit = {},
     onBack: () -> Unit
 ) {
     val scope = rememberCoroutineScope()
@@ -299,6 +302,45 @@ fun SettingsScreen(
                                     }
                                 }
                             )
+                        }
+                    }
+
+                    // Data Management
+                    item {
+                        Card(
+                            onClick = onOpenDataManagement,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(
+                                        imageVector = Icons.Default.Storage,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary
+                                    )
+                                    Column(modifier = Modifier.padding(start = 12.dp)) {
+                                        Text(
+                                            text = "Gestion des données",
+                                            style = MaterialTheme.typography.titleSmall
+                                        )
+                                        Text(
+                                            text = if (isGuest) {
+                                                "Supprimer les données invité"
+                                            } else {
+                                                "Supprimer le compte"
+                                            },
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/composeApp/src/commonMain/kotlin/com/guyghost/wakeve/ui/auth/AuthViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/guyghost/wakeve/ui/auth/AuthViewModel.kt
@@ -83,6 +83,7 @@ class AuthViewModel(
                     is AuthContract.SideEffect.ShowOTPInput -> AuthSideEffect.ShowOTPInput(effect.email, effect.remainingSeconds)
                     is AuthContract.SideEffect.HapticFeedback -> AuthSideEffect.HapticFeedback
                     is AuthContract.SideEffect.AnimateSuccess -> AuthSideEffect.AnimateSuccess
+                    is AuthContract.SideEffect.NavigateToAuthAfterDeletion -> AuthSideEffect.NavigateToAuth
                 }
                 _sideEffects.emit(uiEffect)
             }
@@ -163,6 +164,14 @@ class AuthViewModel(
      */
     fun signOut() {
         authStateMachine.handleIntent(AuthContract.Intent.SignOut)
+    }
+
+    fun deleteCurrentAccount() {
+        authStateMachine.handleIntent(AuthContract.Intent.DeleteAccount)
+    }
+
+    fun deleteGuestData() {
+        authStateMachine.handleIntent(AuthContract.Intent.DeleteGuestData)
     }
 
     /**
@@ -278,4 +287,5 @@ sealed class AuthSideEffect {
     data class ShowOTPInput(val email: String, val remainingSeconds: Int) : AuthSideEffect()
     data object HapticFeedback : AuthSideEffect()
     data object AnimateSuccess : AuthSideEffect()
+    data object NavigateToAuth : AuthSideEffect()
 }


### PR DESCRIPTION
## Summary
- Add `AndroidAccountDeletionGateway` (`DELETE /api/user/delete`)
- Add Data Management screen with destructive confirmation flow
- Expose entry from Settings and wire navigation/DI
- Add Android unit/contract tests

**Stacked on:** #39

## Test plan
- [ ] Settings → Gestion des données → Supprimer le compte (authenticated)
- [ ] Guest data deletion path
- [ ] `./gradlew :composeApp:testDebugUnitTest --tests "*DataManagement*" --tests "*AndroidAccountDeletion*"`

Made with [Cursor](https://cursor.com)